### PR TITLE
feat: add reply command and unified comment listing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build and Install
+
+```bash
+# Build and reinstall extension locally
+go build -o gh-pr-comments . && gh extension remove pr-comments && gh extension install .
+
+# Build only
+go build
+
+# Install from source (first time)
+gh extension install .
+```
+
+## Architecture
+
+This is a GitHub CLI extension (`gh pr-comments`) built with Go and Cobra. It provides structured access to PR reviews and comments that the standard `gh` CLI lacks.
+
+### Package Structure
+
+- `cmd/` - Cobra commands (list, reviews, tree, view, reply)
+- `internal/github/` - GitHub API client and types
+
+### Key Components
+
+**client.go** - GitHub API abstraction using both REST and GraphQL:
+- REST API for reviews, review comments, issue comments
+- GraphQL API specifically for fetching `isResolved` status (not available in REST)
+- PR reference parsing (URLs, owner/repo/number, just number, or auto-detect from branch)
+
+**types.go** - Data structures:
+- `Review` - PR reviews with state (APPROVED, CHANGES_REQUESTED, etc.)
+- `ReviewComment` - Inline code comments on specific file/line
+- `IssueComment` - General PR comments (not attached to code)
+
+### Comment Types
+
+| Type | Description | Has file/line |
+|------|-------------|---------------|
+| Review | Review with state | No |
+| ReviewComment | Inline code comment | Yes |
+| IssueComment | General PR comment | No |
+
+### Filtering Behavior
+
+- Resolved comments are hidden by default in `list` and `tree` commands
+- Use `--all` to show resolved, or `--resolved=true` to show only resolved
+- `--outdated` filters by whether the code has changed since the comment

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+.PHONY: help build clean install
+
+BINARY_NAME := gh-pr-comments
+
+help:
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Targets:"
+	@echo "  help     Show this help message"
+	@echo "  build    Build the extension binary"
+	@echo "  clean    Remove build artifacts"
+	@echo "  install  Clean, build, and reinstall the extension"
+
+build:
+	go build -o $(BINARY_NAME) .
+
+clean:
+	rm -f $(BINARY_NAME)
+
+install: clean build
+	gh extension remove pr-comments || true
+	gh extension install .

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -11,19 +11,21 @@ import (
 )
 
 var (
-	listJsonOutput bool
-	listReviewID   int64
-	listOutdated   string
-	listResolved   string
-	listAll        bool
+	listJsonOutput  bool
+	listReviewID    int64
+	listOutdated    string
+	listResolved    string
+	listAll         bool
+	listCommentType string
 )
 
 var listCmd = &cobra.Command{
 	Use:   "list [pr-reference]",
-	Short: "List review comments on a pull request",
-	Long: `List all review comments (inline code comments) on a pull request.
+	Short: "List all comments on a pull request",
+	Long: `List all comments on a pull request, including both review comments
+(inline code comments) and issue comments (general PR comments).
 
-By default, resolved comments are hidden. Use --all to show all comments,
+By default, resolved review comments are hidden. Use --all to show all comments,
 or --resolved=true to show only resolved comments.
 
 If no PR reference is given, finds the PR for the current branch.
@@ -37,6 +39,8 @@ PR reference can be:
 Examples:
   gh pr-comments list
   gh pr-comments list --all
+  gh pr-comments list --type=review
+  gh pr-comments list --type=issue
   gh pr-comments list --resolved=true
   gh pr-comments list https://github.com/owner/repo/pull/123
   gh pr-comments list owner/repo/123 --review-id=3581523351
@@ -48,10 +52,24 @@ Examples:
 
 func init() {
 	listCmd.Flags().BoolVar(&listJsonOutput, "json", false, "Output in JSON format")
-	listCmd.Flags().Int64Var(&listReviewID, "review-id", 0, "Filter by review ID")
-	listCmd.Flags().StringVar(&listOutdated, "outdated", "", "Filter by outdated status (true/false)")
-	listCmd.Flags().StringVar(&listResolved, "resolved", "", "Filter by resolved status (true/false)")
+	listCmd.Flags().Int64Var(&listReviewID, "review-id", 0, "Filter by review ID (review comments only)")
+	listCmd.Flags().StringVar(&listOutdated, "outdated", "", "Filter by outdated status (true/false, review comments only)")
+	listCmd.Flags().StringVar(&listResolved, "resolved", "", "Filter by resolved status (true/false, review comments only)")
 	listCmd.Flags().BoolVar(&listAll, "all", false, "Show all comments including resolved")
+	listCmd.Flags().StringVar(&listCommentType, "type", "", "Filter by comment type (review/issue)")
+}
+
+type unifiedComment struct {
+	Type       string `json:"type"`
+	ID         int64  `json:"id"`
+	Author     string `json:"author"`
+	Body       string `json:"body"`
+	CreatedAt  string `json:"created_at"`
+	File       string `json:"file,omitempty"`
+	Line       string `json:"line,omitempty"`
+	Outdated   string `json:"outdated,omitempty"`
+	Resolved   string `json:"resolved,omitempty"`
+	ReviewID   int64  `json:"review_id,omitempty"`
 }
 
 func runList(cmd *cobra.Command, args []string) error {
@@ -65,47 +83,80 @@ func runList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	comments, err := client.GetReviewComments(prRef.Owner, prRef.Repo, prRef.Number)
-	if err != nil {
-		return err
+	var allComments []unifiedComment
+
+	if listCommentType == "" || listCommentType == "review" {
+		reviewComments, err := client.GetReviewComments(prRef.Owner, prRef.Repo, prRef.Number)
+		if err != nil {
+			return err
+		}
+		filtered := filterReviewComments(reviewComments)
+		for _, c := range filtered {
+			line := ""
+			if c.OriginalLine != nil {
+				line = fmt.Sprintf("%d", *c.OriginalLine)
+			}
+			outdated := "false"
+			if c.IsOutdated() {
+				outdated = "true"
+			}
+			resolved := "false"
+			if c.IsResolved {
+				resolved = "true"
+			}
+			allComments = append(allComments, unifiedComment{
+				Type:      "review",
+				ID:        c.ID,
+				Author:    c.User.Login,
+				Body:      c.Body,
+				CreatedAt: c.CreatedAt.Format("2006-01-02 15:04"),
+				File:      c.Path,
+				Line:      line,
+				Outdated:  outdated,
+				Resolved:  resolved,
+				ReviewID:  c.PullRequestReviewID,
+			})
+		}
 	}
 
-	filtered := filterComments(comments)
+	if listCommentType == "" || listCommentType == "issue" {
+		issueComments, err := client.GetIssueComments(prRef.Owner, prRef.Repo, prRef.Number)
+		if err != nil {
+			return err
+		}
+		for _, c := range issueComments {
+			allComments = append(allComments, unifiedComment{
+				Type:      "issue",
+				ID:        c.ID,
+				Author:    c.User.Login,
+				Body:      c.Body,
+				CreatedAt: c.CreatedAt.Format("2006-01-02 15:04"),
+			})
+		}
+	}
 
 	if listJsonOutput {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
-		return enc.Encode(filtered)
+		return enc.Encode(allComments)
 	}
 
-	if len(filtered) == 0 {
-		fmt.Println("No review comments found.")
+	if len(allComments) == 0 {
+		fmt.Println("No comments found.")
 		return nil
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "ID\tFILE\tLINE\tOUTDATED\tRESOLVED\tREVIEW ID\tAUTHOR\tBODY")
-	for _, c := range filtered {
-		line := ""
-		if c.OriginalLine != nil {
-			line = fmt.Sprintf("%d", *c.OriginalLine)
-		}
-		outdated := "false"
-		if c.IsOutdated() {
-			outdated = "true"
-		}
-		resolved := "false"
-		if c.IsResolved {
-			resolved = "true"
-		}
+	fmt.Fprintln(w, "TYPE\tID\tFILE\tLINE\tOUTDATED\tRESOLVED\tAUTHOR\tBODY")
+	for _, c := range allComments {
 		body := github.TruncateString(c.Body, 40)
-		fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t%d\t%s\t%s\n",
-			c.ID, c.Path, line, outdated, resolved, c.PullRequestReviewID, c.User.Login, body)
+		fmt.Fprintf(w, "%s\t%d\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			c.Type, c.ID, c.File, c.Line, c.Outdated, c.Resolved, c.Author, body)
 	}
 	return w.Flush()
 }
 
-func filterComments(comments []github.ReviewComment) []github.ReviewComment {
+func filterReviewComments(comments []github.ReviewComment) []github.ReviewComment {
 	var result []github.ReviewComment
 	for _, c := range comments {
 		if listReviewID != 0 && c.PullRequestReviewID != listReviewID {

--- a/cmd/reply.go
+++ b/cmd/reply.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/STRRL/gh-pr-comments/internal/github"
+	"github.com/spf13/cobra"
+)
+
+var (
+	replyBody       string
+	replyPR         string
+	replyJsonOutput bool
+)
+
+var replyCmd = &cobra.Command{
+	Use:   "reply <comment-id>",
+	Short: "Reply to a review comment",
+	Long: `Reply to a review comment on a pull request.
+
+The reply will be added as a threaded response to the specified review comment.
+The comment-id can be found from the 'list', 'view', or 'tree' command output.
+
+Note: Only review comments (inline code comments) support threaded replies.
+Issue comments (general PR comments) do not support threading.
+
+Examples:
+  # Reply using --body flag
+  gh pr-comments reply 2621968472 --body "Thanks for the feedback!"
+
+  # Reply using stdin (useful for multi-line messages)
+  echo "Will fix!" | gh pr-comments reply 2621968472
+
+  # Specify PR explicitly
+  gh pr-comments reply 2621968472 --pr owner/repo/99 --body "Fixed"
+
+  # Reply with JSON output
+  gh pr-comments reply 2621968472 --body "Done" --json`,
+	Args: cobra.ExactArgs(1),
+	RunE: runReply,
+}
+
+func init() {
+	replyCmd.Flags().StringVar(&replyBody, "body", "", "Reply message body (reads from stdin if not provided)")
+	replyCmd.Flags().StringVar(&replyPR, "pr", "", "PR reference (e.g., owner/repo/123 or just 123)")
+	replyCmd.Flags().BoolVar(&replyJsonOutput, "json", false, "Output in JSON format")
+	rootCmd.AddCommand(replyCmd)
+}
+
+func runReply(cmd *cobra.Command, args []string) error {
+	client, err := github.NewClient()
+	if err != nil {
+		return err
+	}
+
+	commentIDStr := args[0]
+	commentID, err := strconv.ParseInt(commentIDStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid comment ID: %s", commentIDStr)
+	}
+
+	body, err := getReplyBody()
+	if err != nil {
+		return err
+	}
+
+	var prArgs []string
+	if replyPR != "" {
+		prArgs = []string{replyPR}
+	}
+
+	prRef, err := client.ResolvePRReference(prArgs)
+	if err != nil {
+		return fmt.Errorf("could not determine PR: %w\nPlease specify a PR with --pr or run from a branch with an associated PR", err)
+	}
+
+	found, err := findReviewComment(client, prRef, commentID)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("review comment with ID %d not found in PR %d\nNote: Only review comments support threaded replies", commentID, prRef.Number)
+	}
+
+	reply, err := client.ReplyToReviewComment(prRef.Owner, prRef.Repo, prRef.Number, commentID, body)
+	if err != nil {
+		return err
+	}
+
+	if replyJsonOutput {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(reply)
+	}
+
+	printReplySuccess(reply, body)
+	return nil
+}
+
+func getReplyBody() (string, error) {
+	if replyBody != "" {
+		return replyBody, nil
+	}
+
+	stat, err := os.Stdin.Stat()
+	if err != nil {
+		return "", fmt.Errorf("failed to check stdin: %w", err)
+	}
+
+	if (stat.Mode() & os.ModeCharDevice) == 0 {
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return "", fmt.Errorf("failed to read from stdin: %w", err)
+		}
+		body := strings.TrimSpace(string(data))
+		if body != "" {
+			return body, nil
+		}
+	}
+
+	return "", fmt.Errorf("reply body required: use --body flag or pipe content via stdin")
+}
+
+func findReviewComment(client *github.Client, prRef *github.PRReference, commentID int64) (bool, error) {
+	comments, err := client.GetReviewComments(prRef.Owner, prRef.Repo, prRef.Number)
+	if err != nil {
+		return false, err
+	}
+
+	for _, c := range comments {
+		if c.ID == commentID {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func printReplySuccess(reply *github.ReviewComment, body string) {
+	fmt.Println("Reply created successfully!")
+	fmt.Println(strings.Repeat("─", 60))
+	fmt.Printf("ID:      %d\n", reply.ID)
+	fmt.Printf("Author:  %s\n", reply.User.Login)
+	fmt.Printf("Created: %s\n", reply.CreatedAt.Format("2006-01-02 15:04:05"))
+	fmt.Printf("URL:     %s\n", reply.HTMLURL)
+	fmt.Println(strings.Repeat("─", 60))
+	fmt.Println()
+	fmt.Println(body)
+	fmt.Println()
+}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -1,6 +1,8 @@
 package github
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
@@ -153,6 +155,20 @@ func (c *Client) GetIssueComments(owner, repo string, number int) ([]IssueCommen
 		return nil, fmt.Errorf("failed to get issue comments: %w", err)
 	}
 	return comments, nil
+}
+
+func (c *Client) ReplyToReviewComment(owner, repo string, prNumber int, commentID int64, body string) (*ReviewComment, error) {
+	var reply ReviewComment
+	path := fmt.Sprintf("repos/%s/%s/pulls/%d/comments/%d/replies", owner, repo, prNumber, commentID)
+	payload := map[string]string{"body": body}
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode request body: %w", err)
+	}
+	if err := c.rest.Post(path, bytes.NewBuffer(jsonData), &reply); err != nil {
+		return nil, fmt.Errorf("failed to reply to comment: %w", err)
+	}
+	return &reply, nil
 }
 
 func (pr *PRReference) ResolveOwnerRepo(c *Client) error {


### PR DESCRIPTION
Add new 'reply' command to create threaded responses to review comments. Extend 'list' command to display both review comments and issue comments in a unified view with type filtering support.

Changes:
- Add cmd/reply.go with stdin and --body flag support for reply text
- Add ReplyToReviewComment method to GitHub client
- Extend list command with --type filter (review/issue)
- Add unified comment structure for mixed comment type display
- Add CLAUDE.md for codebase documentation
- Add Makefile for build automation

🤖 Generated with [Claude Code](https://claude.com/claude-code)