### PR TITLE
Add shell completion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,56 @@ A review comment is considered **outdated** when `position` or `line` is `null`,
 
 Resolved status is fetched via the GraphQL API (not available in REST). Comments are grouped by review threads, and a thread's `isResolved` status applies to all comments in that thread. By default, resolved comments are hidden in `list` and `tree` commands.
 
+## Shell Completion
+
+Shell completion is available for bash, zsh, fish, and powershell.
+
+### Zsh
+
+```bash
+# Generate and install completion
+gh pr-comments completion zsh > "${fpath[1]}/_gh-pr-comments"
+
+# Make sure completion is enabled in ~/.zshrc:
+# autoload -U compinit; compinit
+
+# Restart your shell or run:
+source ~/.zshrc
+```
+
+### Bash
+
+```bash
+# For current session
+source <(gh pr-comments completion bash)
+
+# For all sessions (Linux)
+gh pr-comments completion bash > /etc/bash_completion.d/gh-pr-comments
+
+# For all sessions (macOS with Homebrew)
+gh pr-comments completion bash > $(brew --prefix)/etc/bash_completion.d/gh-pr-comments
+```
+
+### Fish
+
+```bash
+gh pr-comments completion fish > ~/.config/fish/completions/gh-pr-comments.fish
+```
+
+### PowerShell
+
+```powershell
+gh pr-comments completion powershell | Out-String | Invoke-Expression
+```
+
+### Features
+
+Completions include:
+- Subcommands and flags
+- Dynamic comment ID suggestions for `view` and `reply` commands (with content previews)
+- Dynamic review ID suggestions for `--review-id` flag
+- Flag value suggestions (e.g., `--type`, `--resolved`, `--outdated`)
+
 ## Development
 
 ```bash

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var completionCmd = &cobra.Command{
+	Use:   "completion [bash|zsh|fish|powershell]",
+	Short: "Generate shell completion script",
+	Long: fmt.Sprintf(`Generate shell completion script for gh-pr-comments.
+
+To load completions:
+
+Bash:
+
+  $ source <(%[1]s completion bash)
+
+  # To load completions for each session, execute once:
+  # Linux:
+  $ %[1]s completion bash > /etc/bash_completion.d/%[1]s
+  # macOS:
+  $ %[1]s completion bash > $(brew --prefix)/etc/bash_completion.d/%[1]s
+
+Zsh:
+
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it. You can execute the following once:
+
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for each session, execute once:
+  $ %[1]s completion zsh > "${fpath[1]}/_%[1]s"
+
+  # You will need to start a new shell for this setup to take effect.
+
+fish:
+
+  $ %[1]s completion fish | source
+
+  # To load completions for each session, execute once:
+  $ %[1]s completion fish > ~/.config/fish/completions/%[1]s.fish
+
+PowerShell:
+
+  PS> %[1]s completion powershell | Out-String | Invoke-Expression
+
+  # To load completions for every new session, run:
+  PS> %[1]s completion powershell > %[1]s.ps1
+  # and source this file from your PowerShell profile.
+`, "gh-pr-comments"),
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+	Run: func(cmd *cobra.Command, args []string) {
+		switch args[0] {
+		case "bash":
+			cmd.Root().GenBashCompletion(os.Stdout)
+		case "zsh":
+			cmd.Root().GenZshCompletion(os.Stdout)
+		case "fish":
+			cmd.Root().GenFishCompletion(os.Stdout, true)
+		case "powershell":
+			cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+}

--- a/cmd/completion_helpers.go
+++ b/cmd/completion_helpers.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/STRRL/gh-pr-comments/internal/github"
+	"github.com/spf13/cobra"
+)
+
+func completeCommentIDs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) != 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	client, err := github.NewClient()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	prRef, err := client.ResolvePRReference(nil)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	var completions []string
+
+	reviewComments, err := client.GetReviewComments(prRef.Owner, prRef.Repo, prRef.Number)
+	if err == nil {
+		for _, c := range reviewComments {
+			desc := github.TruncateString(c.Body, 40)
+			completion := fmt.Sprintf("%d\t[review] %s", c.ID, desc)
+			completions = append(completions, completion)
+		}
+	}
+
+	issueComments, err := client.GetIssueComments(prRef.Owner, prRef.Repo, prRef.Number)
+	if err == nil {
+		for _, c := range issueComments {
+			desc := github.TruncateString(c.Body, 40)
+			completion := fmt.Sprintf("%d\t[issue] %s", c.ID, desc)
+			completions = append(completions, completion)
+		}
+	}
+
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}
+
+func completeReviewCommentIDs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) != 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	client, err := github.NewClient()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	prRef, err := client.ResolvePRReference(nil)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	var completions []string
+
+	reviewComments, err := client.GetReviewComments(prRef.Owner, prRef.Repo, prRef.Number)
+	if err == nil {
+		for _, c := range reviewComments {
+			desc := github.TruncateString(c.Body, 40)
+			completion := fmt.Sprintf("%d\t%s: %s", c.ID, c.Path, desc)
+			completions = append(completions, completion)
+		}
+	}
+
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}
+
+func completeReviewIDs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	client, err := github.NewClient()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	prRef, err := client.ResolvePRReference(nil)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	var completions []string
+
+	reviews, err := client.GetReviews(prRef.Owner, prRef.Repo, prRef.Number)
+	if err == nil {
+		for _, r := range reviews {
+			desc := r.State
+			if r.Body != "" {
+				desc = fmt.Sprintf("%s: %s", r.State, github.TruncateString(r.Body, 30))
+			}
+			completion := fmt.Sprintf("%d\t[%s] %s", r.ID, r.User.Login, desc)
+			completions = append(completions, completion)
+		}
+	}
+
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -57,6 +57,17 @@ func init() {
 	listCmd.Flags().StringVar(&listResolved, "resolved", "", "Filter by resolved status (true/false, review comments only)")
 	listCmd.Flags().BoolVar(&listAll, "all", false, "Show all comments including resolved")
 	listCmd.Flags().StringVar(&listCommentType, "type", "", "Filter by comment type (review/issue)")
+
+	listCmd.RegisterFlagCompletionFunc("review-id", completeReviewIDs)
+	listCmd.RegisterFlagCompletionFunc("type", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"review\tInline code comments", "issue\tGeneral PR comments"}, cobra.ShellCompDirectiveNoFileComp
+	})
+	listCmd.RegisterFlagCompletionFunc("outdated", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"true\tShow only outdated comments", "false\tShow only non-outdated comments"}, cobra.ShellCompDirectiveNoFileComp
+	})
+	listCmd.RegisterFlagCompletionFunc("resolved", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"true\tShow only resolved comments", "false\tShow only unresolved comments"}, cobra.ShellCompDirectiveNoFileComp
+	})
 }
 
 type unifiedComment struct {

--- a/cmd/reply.go
+++ b/cmd/reply.go
@@ -41,8 +41,9 @@ Examples:
 
   # Reply with JSON output
   gh pr-comments reply 2621968472 --body "Done" --json`,
-	Args: cobra.ExactArgs(1),
-	RunE: runReply,
+	Args:              cobra.ExactArgs(1),
+	RunE:              runReply,
+	ValidArgsFunction: completeReviewCommentIDs,
 }
 
 func init() {

--- a/cmd/view.go
+++ b/cmd/view.go
@@ -13,9 +13,9 @@ import (
 var viewJsonOutput bool
 
 var viewCmd = &cobra.Command{
-	Use:     "view <id>",
-	Aliases: []string{"show"},
-	Short:   "View full content of a review comment, review, or issue comment",
+	Use:               "view <id>",
+	Aliases:           []string{"show"},
+	Short:             "View full content of a review comment, review, or issue comment",
 	Long: `View the full content of an item by its ID.
 
 Automatically detects the type (review comment, review, or issue comment).
@@ -26,8 +26,9 @@ Examples:
   gh pr-comments view 2621968472
   gh pr-comments show 3581523351
   gh pr-comments view 2621968472 --json`,
-	Args: cobra.ExactArgs(1),
-	RunE: runView,
+	Args:              cobra.ExactArgs(1),
+	RunE:              runView,
+	ValidArgsFunction: completeCommentIDs,
 }
 
 func init() {


### PR DESCRIPTION
## Summary

Implements shell completion (bash, zsh, fish, powershell) support for `gh-pr-comments` with dynamic completions showing comment/review IDs with content previews.

## Changes

- Added `completion` subcommand generating shell-specific completion scripts
- Dynamic completions for `view` and `reply` commands showing comment IDs with content
- Dynamic completions for `--review-id` flag with review author and state
- Flag value suggestions for filtering options (`--type`, `--resolved`, `--outdated`)
- Updated README with completion setup instructions for all shells

## Testing

Completions tested via Cobra's built-in `__complete` mechanism. Verified working for all shells (zsh, bash, fish, powershell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)