### PR TITLE
feat: add tab completion for hide, resolve, and cleanup

### DIFF
--- a/cmd/cleanup.go
+++ b/cmd/cleanup.go
@@ -57,6 +57,7 @@ func init() {
 	cleanupCmd.Flags().BoolVar(&cleanupDryRun, "dry-run", false, "Preview which reviews would be minimized without making changes")
 	cleanupCmd.Flags().Int64Var(&cleanupReviewID, "review-id", 0, "Only process a specific review ID")
 	cleanupCmd.Flags().BoolVar(&cleanupJsonOutput, "json", false, "Output in JSON format")
+	_ = cleanupCmd.RegisterFlagCompletionFunc("review-id", completeReviewIDs)
 	rootCmd.AddCommand(cleanupCmd)
 }
 

--- a/cmd/completion_helpers.go
+++ b/cmd/completion_helpers.go
@@ -46,9 +46,6 @@ func completeCommentIDs(cmd *cobra.Command, args []string, toComplete string) ([
 }
 
 func completeReviewCommentIDs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	if len(args) != 0 {
-		return nil, cobra.ShellCompDirectiveNoFileComp
-	}
 
 	client, err := github.NewClient()
 	if err != nil {

--- a/cmd/hide.go
+++ b/cmd/hide.go
@@ -21,9 +21,10 @@ var (
 )
 
 var hideCmd = &cobra.Command{
-	Use:   "hide [comment-id]",
-	Short: "Hide (minimize) PR comments",
-	Long: `Hide PR comments by marking them with a reason.
+	Use:               "hide [comment-id]",
+	Short:             "Hide (minimize) PR comments",
+	ValidArgsFunction: completeCommentIDs,
+	Long:              `Hide PR comments by marking them with a reason.
 
 When a comment ID is provided, hides that specific comment.
 When no ID is provided, uses filters to select comments for batch hiding.

--- a/cmd/resolve.go
+++ b/cmd/resolve.go
@@ -18,9 +18,10 @@ var (
 )
 
 var resolveCmd = &cobra.Command{
-	Use:   "resolve <comment-id> [comment-id...]",
-	Short: "Resolve or unresolve review threads",
-	Long: `Mark review comment threads as resolved or unresolve them.
+	Use:               "resolve <comment-id> [comment-id...]",
+	Short:             "Resolve or unresolve review threads",
+	ValidArgsFunction: completeReviewCommentIDs,
+	Long:              `Mark review comment threads as resolved or unresolve them.
 
 The comment-id(s) can be found from the 'list', 'view', or 'tree' command output.
 Each comment belongs to a review thread, and this command resolves/unresolves the


### PR DESCRIPTION
Add shell tab completion for comment ID arguments in `hide` and `resolve` commands, and for the `--review-id` flag in `cleanup`. The `resolve` command now also supports completing multiple comment IDs since it accepts variadic arguments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)